### PR TITLE
Fix docker compose issue on linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,13 @@ Notice that you may have to change the path depending on which Ruby version you 
 
 ### rbenv
 Add this to your ~/.zshrc
-```ruby
+```bash
 alias uno='/Users/$USER/.rvm/gems/ruby-3.0.2/bin/neptuno'
 ```
 
 ### asdf
 Add this to your ~/.zshrc
-```ruby
+```bash
 alias uno='/Users/$USER/.asdf/installs/ruby/3.0.2/bin/neptuno'
 ```
 
@@ -50,6 +50,32 @@ docker_delimiter: "_"
 ```
 The path you need for rbenv and asdf may be different.
 
+## docker-compose\docker compose workaround
+
+Create docker-compole link and add add it to PATH
+with content
+
+```bash
+# /bin/docker-compose
+
+docker compose --compatibility "$@"
+```
+
+```bash
+mkdir -p ~/.local/bin
+cat > ~/.local/bin/docker-compose << EOF
+# /bin/docker-compose
+
+docker compose --compatibility "\$@"
+EOF
+chmod +x ~/.local/bin/docker-compose
+```
+
+Add this to your ~/.zshrc
+
+```bash
+export PATH=$PATH:"$HOME/.local/bin"
+```
 
 ## Development
 

--- a/lib/neptuno/cli/activate.rb
+++ b/lib/neptuno/cli/activate.rb
@@ -16,7 +16,7 @@ module Neptuno
         spinners = {}
         count = 0
         command_services_to('activate to services', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker compose up -d #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{services.join(' ')}")
           running_services = ::Neptuno::CLI::List.new.running_services.first.keys
           running_services.sort.each do |service|
             spinners[service] ||= multi_spinner.register("[:spinner] :state #{service}")
@@ -24,7 +24,7 @@ module Neptuno
             spinners[service].auto_spin
           end
           loop do
-            ps = `cd #{neptuno_path} && docker compose ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
+            ps = `cd #{neptuno_path} && #{docker_compose} ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
 
             running_services.sort.each do |service|
               service_ps = ps.find {|s| s =~ /#{project}[-_]#{service}[-_]\d\s/ }

--- a/lib/neptuno/cli/install.rb
+++ b/lib/neptuno/cli/install.rb
@@ -20,6 +20,7 @@ module Neptuno
         install 'tmux'
         install 'overmind'
         install 'tmuxinator'
+        install_docker_compose
       end
 
       def install(package)
@@ -28,6 +29,17 @@ module Neptuno
         else
           puts "Installing #{package}"
           system("brew install #{package}")
+        end
+      end
+
+      private
+
+      def install_docker_compose
+        if Neptuno::Docker::Compose.installed?
+          puts 'docker compose is already installed'
+        else
+          puts 'Installing instruction https://docs.docker.com/compose/install'
+          system('brew install docker-compose-plugin')
         end
       end
     end

--- a/lib/neptuno/cli/install.rb
+++ b/lib/neptuno/cli/install.rb
@@ -35,7 +35,7 @@ module Neptuno
       private
 
       def install_docker_compose
-        if Neptuno::Docker::Compose.installed?
+        if Neptuno::Docker::Compose.new.installed?
           puts 'docker compose is already installed'
         else
           puts 'Installing instruction https://docs.docker.com/compose/install'

--- a/lib/neptuno/cli/list.rb
+++ b/lib/neptuno/cli/list.rb
@@ -24,7 +24,7 @@ module Neptuno
         end.to_h
 
         begin
-          docker_containers = `docker compose ps`.lines[1..]
+          docker_containers = `#{docker_compose} ps`.lines[1..]
           raise if $?.exitstatus != 0
         rescue RuntimeError
           exit

--- a/lib/neptuno/docker/attach.rb
+++ b/lib/neptuno/docker/attach.rb
@@ -10,7 +10,7 @@ module Neptuno
 
       def call(**options)
         command_service_to('attach', service_as_args: options[:args].first) do |service, project|
-          system("cd #{neptuno_path} && docker compose up -d #{service}") if options.fetch(:up)
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{service}") if options.fetch(:up)
           success = system("cd #{neptuno_path} && docker attach #{project}_#{service}_1")
           unless success
             puts "Trying #{project}-#{services.first}-1"

--- a/lib/neptuno/docker/build.rb
+++ b/lib/neptuno/docker/build.rb
@@ -11,7 +11,7 @@ module Neptuno
 
       def call(services: [], **options)
         command_services_to('build', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker compose build #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} build #{services.join(' ')}")
         end
       end
     end

--- a/lib/neptuno/docker/compose.rb
+++ b/lib/neptuno/docker/compose.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Neptuno
+  module Docker
+    # Docker compose caller
+    class Compose
+      STANDALONE_COMMAND = 'docker-compose'
+      COMPOSE_V2_COMMAND = 'docker compose'
+
+      def command
+        standalone? ? STANDALONE_COMMAND : COMPOSE_V2_COMMAND
+      end
+
+      private
+
+      def standalone?
+        @standalone = ::TTY::Which.exist?(STANDALONE_COMMAND)
+      end
+    end
+  end
+end

--- a/lib/neptuno/docker/compose.rb
+++ b/lib/neptuno/docker/compose.rb
@@ -4,23 +4,27 @@ module Neptuno
   module Docker
     # Docker compose caller
     class Compose
-      extend Neptuno::TTY::Command
+      include Neptuno::TTY::Command
 
       STANDALONE_COMMAND = 'docker-compose'
       COMPOSE_V2_COMMAND = 'docker compose'
 
-      def self.installed?
-        ::TTY::Which.exist?('docker-compose') || !command.run!('docker compose version').failure?
+      def compose_command
+        compose_v2? ? COMPOSE_V2_COMMAND : STANDALONE_COMMAND
       end
 
-      def command
-        standalone? ? STANDALONE_COMMAND : COMPOSE_V2_COMMAND
+      def installed?
+        standalone? || compose_v2?
       end
 
       private
 
       def standalone?
         @standalone = ::TTY::Which.exist?(STANDALONE_COMMAND)
+      end
+
+      def compose_v2?
+        !command.run!('docker compose version').failure?
       end
     end
   end

--- a/lib/neptuno/docker/compose.rb
+++ b/lib/neptuno/docker/compose.rb
@@ -4,8 +4,14 @@ module Neptuno
   module Docker
     # Docker compose caller
     class Compose
+      extend Neptuno::TTY::Command
+
       STANDALONE_COMMAND = 'docker-compose'
       COMPOSE_V2_COMMAND = 'docker compose'
+
+      def self.installed?
+        ::TTY::Which.exist?('docker-compose') || !command.run!('docker compose version').failure?
+      end
 
       def command
         standalone? ? STANDALONE_COMMAND : COMPOSE_V2_COMMAND

--- a/lib/neptuno/docker/down.rb
+++ b/lib/neptuno/docker/down.rb
@@ -12,8 +12,8 @@ module Neptuno
 
       def call(services: [], **options)
         command_services_to('go down', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker compose stop -t 0 #{services.join(' ')}")
-          system("cd #{neptuno_path} && docker compose rm -f #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} stop -t 0 #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} rm -f #{services.join(' ')}")
           system("cd #{neptuno_path} && tmux kill-session -t neptuno") if options.fetch(:tmux)
           system("cd #{neptuno_path}/procfiles/#{service} && rm .overmind.sock  > /dev/null 2>&1")
         end

--- a/lib/neptuno/docker/restart.rb
+++ b/lib/neptuno/docker/restart.rb
@@ -11,10 +11,10 @@ module Neptuno
 
       def call(services: [], **options)
         command_services_to('restart', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker compose stop -t 0 #{services.join(' ')}")
-          system("cd #{neptuno_path} && docker compose rm -f #{services.join(' ')}")
-          system("cd #{neptuno_path} && docker compose build #{services.join(' ')}")
-          system("cd #{neptuno_path} && docker compose up -d #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} stop -t 0 #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} rm -f #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} build #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{services.join(' ')}")
         end
       end
     end

--- a/lib/neptuno/docker/services.rb
+++ b/lib/neptuno/docker/services.rb
@@ -7,7 +7,7 @@ module Neptuno
       require 'yaml'
 
       def running_services
-        running_services = `cd ~/.neptuno/projects/#{current_project} && docker compose ps | awk '{ print $3 }' | awk 'NR>1'`
+        running_services = `cd ~/.neptuno/projects/#{current_project} && #{docker_compose} ps | awk '{ print $3 }' | awk 'NR>1'`
         running_services.split("\n").map(&:strip)
       end
 

--- a/lib/neptuno/docker/up.rb
+++ b/lib/neptuno/docker/up.rb
@@ -12,7 +12,7 @@ module Neptuno
 
       def call(services: [], **options)
         command_services_to('come up', all: options.fetch(:all), services_as_args: services) do |services, project|
-          system("cd #{neptuno_path} && docker compose up -d #{services.join(' ')}")
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{services.join(' ')}")
           success = system("cd #{neptuno_path} && docker logs -f #{project}_#{services.first}_1") if options.fetch(:log)
           unless success
             puts "Trying #{project}-#{services.first}-1"

--- a/lib/neptuno/overmind/connect.rb
+++ b/lib/neptuno/overmind/connect.rb
@@ -19,7 +19,7 @@ module Neptuno
         spinners = {}
         count = 0
         command_services_to('connect to procs', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker-compose up -d #{services.join(' ')}") if options.fetch(:up)
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{services.join(' ')}") if options.fetch(:up)
           running_services = ::Neptuno::CLI::List.new.running_services.first.keys
           running_services.sort.each do |service|
             spinners[service] ||= multi_spinner.register("[:spinner] :state #{service}")
@@ -27,7 +27,7 @@ module Neptuno
             spinners[service].auto_spin
           end
           loop do
-            ps = `cd #{neptuno_path} && docker-compose ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
+            ps = `cd #{neptuno_path} && #{docker_compose} ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
 
             running_services.sort.each do |service|
               service_ps = ps.find {|s| s =~ /#{project}[-_]#{service}[-_]\d\s/ }

--- a/lib/neptuno/overmind/connect.rb
+++ b/lib/neptuno/overmind/connect.rb
@@ -87,7 +87,7 @@ module Neptuno
               begin
                 system("cd #{neptuno_path}/procfiles/#{services.first} && overmind connect shell", exception: true)
               rescue RuntimeError
-                system("cd #{neptuno_path} && docker compose exec #{service} kill -9 -1")
+                system("cd #{neptuno_path} && #{docker_compose} exec #{service} kill -9 -1")
                 system("cd #{neptuno_path}/procfiles/#{service} && rm .overmind.sock  > /dev/null 2>&1")
                 system("cd #{neptuno_path}/procfiles/#{service} && overmind start -D -N  > /dev/null 2>&1")
                 retry

--- a/lib/neptuno/overmind/start.rb
+++ b/lib/neptuno/overmind/start.rb
@@ -17,7 +17,7 @@ module Neptuno
         spinners = {}
         count = 0
         command_services_to('connect to procs', all: options.fetch(:all), services_as_args: services) do |services|
-          system("cd #{neptuno_path} && docker compose up -d #{services.join(' ')}") if options.fetch(:up)
+          system("cd #{neptuno_path} && #{docker_compose} up -d #{services.join(' ')}") if options.fetch(:up)
           running_services = ::Neptuno::CLI::List.new.running_services.first.keys
           running_services.sort.each do |service|
             spinners[service] ||= multi_spinner.register("[:spinner] :state #{service}")
@@ -25,7 +25,7 @@ module Neptuno
             spinners[service].auto_spin
           end
           loop do
-            ps = `cd #{neptuno_path} && docker compose ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
+            ps = `cd #{neptuno_path} && #{docker_compose} ps`.split("\n").compact.select { |x| x.match(/^\s*#{project}/) }
 
             running_services.sort.each do |service|
               service_ps = ps.find {|s| s =~ /#{project}[-_]#{service}[-_]\d\s/ }

--- a/lib/neptuno/overmind/stop.rb
+++ b/lib/neptuno/overmind/stop.rb
@@ -12,7 +12,7 @@ module Neptuno
       def call(services: [], **options)
         command_services_to('stop procs', all: options.fetch(:all), services_as_args: services) do |services|
           services.each do |service|
-            system("cd #{neptuno_path} && docker compose exec #{service} kill -9 -1")
+            system("cd #{neptuno_path} && #{docker_compose} exec #{service} kill -9 -1")
             system("cd #{neptuno_path}/procfiles/#{service} && rm .overmind.sock  > /dev/null 2>&1")
           end
         end

--- a/lib/neptuno/tty/command.rb
+++ b/lib/neptuno/tty/command.rb
@@ -19,6 +19,10 @@ module Neptuno
       def neptuno_command(command)
         `cd #{neptuno_path} && #{command}`
       end
+
+      def docker_compose
+        @docker_compose ||= Neptuno::Docker::Compose.new.command
+      end
     end
   end
 end

--- a/lib/neptuno/tty/command.rb
+++ b/lib/neptuno/tty/command.rb
@@ -21,7 +21,7 @@ module Neptuno
       end
 
       def docker_compose
-        @docker_compose ||= Neptuno::Docker::Compose.new.command
+        @docker_compose ||= Neptuno::Docker::Compose.new.compose_command
       end
     end
   end

--- a/test/ude/docker/compose_test.rb
+++ b/test/ude/docker/compose_test.rb
@@ -20,4 +20,37 @@ describe Neptuno::Docker::Compose do
       end
     end
   end
+
+  describe '.installed?' do
+    it 'when docker-compose exists' do
+      TTY::Which.stub(:exist?, true, 'docker-compose') do
+        assert_equal true, Neptuno::Docker::Compose.installed?
+      end
+    end
+
+    it 'when docker compose returns version' do
+      run_result_mock = MiniTest::Mock.new
+      run_result_mock.expect(:failure?, false)
+      command_mock = MiniTest::Mock.new
+      command_mock.expect(:run!, run_result_mock, ['docker compose version'])
+
+      TTY::Which.stub(:exist?, false, 'docker-compose') do
+        Neptuno::Docker::Compose.stub(:command, command_mock) do
+          assert_equal true, Neptuno::Docker::Compose.installed?
+        end
+      end
+    end
+
+    it 'when no docker compose' do
+      run_result_mock = MiniTest::Mock.new
+      run_result_mock.expect(:failure?, true)
+      command_mock = MiniTest::Mock.new
+      command_mock.expect(:run!, run_result_mock, ['docker compose version'])
+      TTY::Which.stub(:exist?, false, 'docker-compose') do
+        Neptuno::Docker::Compose.stub(:command, command_mock) do
+          assert_equal false, Neptuno::Docker::Compose.installed?
+        end
+      end
+    end
+  end
 end

--- a/test/ude/docker/compose_test.rb
+++ b/test/ude/docker/compose_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+describe Neptuno::Docker::Compose do
+  describe '#command' do
+    describe 'when docker-compose exists' do
+      it "returns 'docker-compose'" do
+        TTY::Which.stub(:exist?, true) do
+          assert_equal 'docker-compose', Neptuno::Docker::Compose.new.command
+        end
+      end
+    end
+
+    describe 'when docker compose installed as plugin' do
+      it "returns 'docker compose'" do
+        TTY::Which.stub(:exist?, false) do
+          assert_equal 'docker compose', Neptuno::Docker::Compose.new.command
+        end
+      end
+    end
+  end
+end

--- a/test/ude/docker/compose_test.rb
+++ b/test/ude/docker/compose_test.rb
@@ -3,52 +3,59 @@
 require 'test_helper'
 
 describe Neptuno::Docker::Compose do
-  describe '#command' do
+  before do
+    @compose = Neptuno::Docker::Compose.new
+  end
+
+  def with_command_stub(failure: false, &block)
+    run_result_mock = MiniTest::Mock.new
+    run_result_mock.expect(:failure?, failure)
+    command_mock = MiniTest::Mock.new
+    command_mock.expect(:run!, run_result_mock, ['docker compose version'])
+    @compose.stub(:command, command_mock) do
+      yield block
+    end
+  end
+
+  describe '#compose_command' do
     describe 'when docker-compose exists' do
       it "returns 'docker-compose'" do
-        TTY::Which.stub(:exist?, true) do
-          assert_equal 'docker-compose', Neptuno::Docker::Compose.new.command
+        with_command_stub(failure: true) do
+          assert_equal 'docker-compose', @compose.compose_command
         end
       end
     end
 
     describe 'when docker compose installed as plugin' do
       it "returns 'docker compose'" do
-        TTY::Which.stub(:exist?, false) do
-          assert_equal 'docker compose', Neptuno::Docker::Compose.new.command
+        with_command_stub(failure: false) do
+          assert_equal 'docker compose', @compose.compose_command
         end
       end
     end
   end
 
-  describe '.installed?' do
+  describe '#installed?' do
     it 'when docker-compose exists' do
-      TTY::Which.stub(:exist?, true, 'docker-compose') do
-        assert_equal true, Neptuno::Docker::Compose.installed?
+      with_command_stub(failure: true) do
+        TTY::Which.stub(:exist?, true, 'docker-compose') do
+          assert_equal true, @compose.installed?
+        end
       end
     end
 
     it 'when docker compose returns version' do
-      run_result_mock = MiniTest::Mock.new
-      run_result_mock.expect(:failure?, false)
-      command_mock = MiniTest::Mock.new
-      command_mock.expect(:run!, run_result_mock, ['docker compose version'])
-
-      TTY::Which.stub(:exist?, false, 'docker-compose') do
-        Neptuno::Docker::Compose.stub(:command, command_mock) do
-          assert_equal true, Neptuno::Docker::Compose.installed?
+      with_command_stub(failure: false) do
+        TTY::Which.stub(:exist?, false, 'docker-compose') do
+          assert_equal true, @compose.installed?
         end
       end
     end
 
     it 'when no docker compose' do
-      run_result_mock = MiniTest::Mock.new
-      run_result_mock.expect(:failure?, true)
-      command_mock = MiniTest::Mock.new
-      command_mock.expect(:run!, run_result_mock, ['docker compose version'])
-      TTY::Which.stub(:exist?, false, 'docker-compose') do
-        Neptuno::Docker::Compose.stub(:command, command_mock) do
-          assert_equal false, Neptuno::Docker::Compose.installed?
+      with_command_stub(failure: true) do
+        TTY::Which.stub(:exist?, false, 'docker-compose') do
+          assert_equal false, @compose.installed?
         end
       end
     end

--- a/test/ude/overmind/connect_test.rb
+++ b/test/ude/overmind/connect_test.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './test/ude/support/cli_ovverides'
+
+describe Neptuno::Overmind::Connect do
+  describe '#call' do
+    before do
+      @connect = Neptuno::Overmind::Connect.new
+      @options = { all: nil, up: true, procfile_manager: 'overmind', tmux: nil, force: false }
+
+      @cli_list_mock = Minitest::Mock.new
+      @system_mock = MiniTest::Mock.new
+      @compose_mock = MiniTest::Mock.new
+      @compose_mock.expect(:command, 'docker-compose')
+    end
+
+    it 'call docker compose up' do
+      services = ['foo']
+
+      @cli_list_mock.expect :running_services, [{ 'foo' => 0, 'bar' => 1 }]
+
+      @system_mock.expect :call, nil, ['cd /app/test-neptuno && docker-compose up -d foo']
+      @system_mock.expect :call, nil, ['cd /app/test-neptuno/procfiles/foo && overmind start -D -N  > /dev/null 2>&1']
+      @system_mock.expect(:call, nil) do |str, opt|
+        str == 'cd /app/test-neptuno/procfiles/foo && overmind connect shell' && opt == { exception: true }
+      end
+
+      slash_result = "tst-foo-1 (healthy)\n tst-bar-1"
+
+      Neptuno::CLI::List.stub(:new, @cli_list_mock) do
+        Neptuno::Docker::Compose.stub(:new, @compose_mock) do
+          @connect.stub(:neptuno_path, '/app/test-neptuno') do
+            @connect.stub(:project, 'tst') do
+              @connect.stub(:system, @system_mock) do
+                @connect.stub(:`, slash_result) do
+                  @connect.stub(:sleep, nil) do
+                    @connect.call(services: services, **@options)
+                    @cli_list_mock.verify
+                    @system_mock.verify
+                    @compose_mock.verify
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/ude/overmind/connect_test.rb
+++ b/test/ude/overmind/connect_test.rb
@@ -12,7 +12,7 @@ describe Neptuno::Overmind::Connect do
       @cli_list_mock = Minitest::Mock.new
       @system_mock = MiniTest::Mock.new
       @compose_mock = MiniTest::Mock.new
-      @compose_mock.expect(:command, 'docker-compose')
+      @compose_mock.expect(:compose_command, 'docker-compose')
     end
 
     it 'call docker compose up' do

--- a/test/ude/support/cli_ovverides.rb
+++ b/test/ude/support/cli_ovverides.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'neptuno/cli'
+
+# Allow to pass initialize without neptuno config
+
+module Neptuno
+  module Overmind
+    class Connect
+      def initialize; end
+    end
+  end
+end

--- a/test/ude/tty/command_test.rb
+++ b/test/ude/tty/command_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestNeptunoTTYCommandClass
+  include ::Neptuno::TTY::Command
+end
+
+describe Neptuno::TTY::Command do
+  describe '#docker_compose' do
+    it 'returns Docker#Compose#command' do
+      compose_mock = MiniTest::Mock.new
+      compose_mock.expect :command, 'foo'
+      Neptuno::Docker::Compose.stub :new, compose_mock do
+        test_inst = TestNeptunoTTYCommandClass.new
+        assert_equal 'foo', test_inst.docker_compose
+      end
+    end
+  end
+end

--- a/test/ude/tty/command_test.rb
+++ b/test/ude/tty/command_test.rb
@@ -10,7 +10,7 @@ describe Neptuno::TTY::Command do
   describe '#docker_compose' do
     it 'returns Docker#Compose#command' do
       compose_mock = MiniTest::Mock.new
-      compose_mock.expect :command, 'foo'
+      compose_mock.expect :compose_command, 'foo'
       Neptuno::Docker::Compose.stub :new, compose_mock do
         test_inst = TestNeptunoTTYCommandClass.new
         assert_equal 'foo', test_inst.docker_compose


### PR DESCRIPTION
# Description

As **docker compose** goes as a [plugin](https://docs.docker.com/compose/install/) now there are some issues on linux systems.
Previous call `docker-compose` 
new one `docker compose`
There are two types of calls at the same time
E.g.
`docker-compose`
https://github.com/apptegy/neptuno/blob/2340d26ed54ff0be8e06af39cb4e2e83af7eea12/lib/neptuno/overmind/connect.rb#L22
https://github.com/apptegy/neptuno/blob/2340d26ed54ff0be8e06af39cb4e2e83af7eea12/lib/neptuno/overmind/connect.rb#L30

`docker compose`
https://github.com/apptegy/neptuno/blob/84fc1aa2bf66e99aae2adcd369cced6750b48898/lib/neptuno/docker/restart.rb#L14-L17
https://github.com/apptegy/neptuno/blob/84fc1aa2bf66e99aae2adcd369cced6750b48898/lib/neptuno/docker/build.rb#L14

## Fixes to make it works
- Unified docker-compose\docker compose calls
- Added docker main call with version check (`docker compose` by default)
- Added `docker compose` to **cli install**
- Fixed one bug with initialized status in a loop
- **Added workaround how to link `docker compose` -> `docker-compose` call for procfiles** 

## Tests
- Added tests for new files
- Added a test to overmind::connect to check correctness of the new call
- Tested manually
           Linux Mint 21 Cinnamon
           Docker 20.10.21
           Docker Compose version v2.12.2
           ruby 3.1.2p20
