### PR TITLE
fix: neptuno activate

### DIFF
--- a/lib/neptuno/cli/activate.rb
+++ b/lib/neptuno/cli/activate.rb
@@ -17,7 +17,7 @@ module Neptuno
         count = 0
         command_services_to("activate to services", all: options.fetch(:all), services_as_args: services) do |services|
           system("cd #{neptuno_path} && docker compose up -d #{services.join(" ")}")
-          running_services = ::Neptuno::CLI::List.new.running_services.first.keys
+          running_services = ::Neptuno::CLI::List.new.running_services # array of services (string)
           running_services.sort.each do |service|
             spinners[service] ||= multi_spinner.register("[:spinner] :state #{service}")
             spinners[service].update(state: "-          ")
@@ -28,7 +28,7 @@ module Neptuno
 
             running_services.sort.each do |service|
               service_ps = ps.find { |s| s =~ /#{project}[-_]#{service}[-_]\d\s/ }
-
+              status = nil
               status = :dead if service_ps.to_s.include?("exited")
               status = :starting if service_ps.to_s.include?("starting")
               status = :unhealthy if service_ps.to_s.include?("(unhealthy")

--- a/test/ude/cli/activate_test.rb
+++ b/test/ude/cli/activate_test.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './test/ude/support/cli_ovverides'
+
+describe Neptuno::CLI::Activate do
+  describe '#call' do
+    project_folder = '/app/test-neptuno'
+    before do
+      @activate = Neptuno::CLI::Activate.new
+      @options = { force: false, all: false }
+
+      @cli_list_mock = Minitest::Mock.new
+      @system_mock = MiniTest::Mock.new
+      @multi_spinner_mock = MiniTest::Mock.new
+      @spinner_inst_mock_foo = MiniTest::Mock.new
+      @last_spinner_mock = MiniTest::Mock.new
+    end
+
+    it 'call docker compose up' do
+      services = %w[foo]
+
+      @cli_list_mock.expect :running_services, services
+      @system_mock.expect :call, nil, ['cd /app/test-neptuno && docker compose up -d foo']
+
+      @multi_spinner_mock.expect(:register, @spinner_inst_mock_foo, [String])
+      @spinner_inst_mock_foo.expect(:update, nil) do |args|
+        assert_equal ({ state: '-          ' }), args
+      end
+
+      @spinner_inst_mock_foo.expect :auto_spin, nil
+      @spinner_inst_mock_foo.expect :instance_variable_get, :stopped, [:@state]
+
+      slash_checker = lambda do |cmd|
+        assert_includes [
+          'cd /app/test-neptuno && docker compose ps',
+          'cd /app/test-neptuno/procfiles/foo && overmind start -D -N  > /dev/null 2>&1'
+        ], cmd
+        "test-neptuno-foo-1 (healthy)\n db (healthy)"
+      end
+
+      @spinner_inst_mock_foo.expect(:update, nil) do |args|
+        assert_equal ({ state: 'ready      ' }), args
+      end
+      @spinner_inst_mock_foo.expect :success, nil
+      @last_spinner_mock.expect :auto_spin, nil
+      @last_spinner_mock.expect :stop, nil
+      TTY::Spinner.stub(:new, @last_spinner_mock) do
+        TTY::Spinner::Multi.stub(:new, @multi_spinner_mock) do
+          Neptuno::CLI::List.stub(:new, @cli_list_mock) do
+            @activate.stub(:neptuno_path, project_folder) do
+              @activate.stub(:system, @system_mock) do
+                @activate.stub(:`, slash_checker) do
+                  @activate.stub(:sleep, nil) do
+                    @activate.call(services: services, **@options)
+                    @cli_list_mock.verify
+                    @system_mock.verify
+                    @multi_spinner_mock.verify
+                    @spinner_inst_mock_foo.verify
+                    @last_spinner_mock.verify
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/ude/cli/list_test.rb
+++ b/test/ude/cli/list_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+require './test/ude/support/cli_ovverides'
+
+describe Neptuno::CLI::List do
+  describe '#running_services' do
+    neptuno_path = '/app/neptuno-test'
+    it 'returns an array of services' do
+      @cli_list = Neptuno::CLI::List.new
+      args_checker = lambda do |cmd|
+        assert_equal 'cd /app/neptuno-test && docker compose ps --status running --services', cmd
+        "foo\nbar"
+      end
+
+      @cli_list.stub(:neptuno_path, neptuno_path) do
+        @cli_list.stub(:`, args_checker) do
+          assert_equal %w[foo bar], @cli_list.running_services
+        end
+      end
+    end
+  end
+end

--- a/test/ude/support/cli_ovverides.rb
+++ b/test/ude/support/cli_ovverides.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'neptuno/cli'
+
+# Allow to pass initialize without neptuno config
+
+module Neptuno
+  module CLI
+    class List
+      def initialize; end
+    end
+
+    class Activate
+      def initialize; end
+    end
+  end
+end


### PR DESCRIPTION
Fix `neptuno activate` command

```bash
bundler: failed to load command: neptuno (/home/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bin/neptuno)
/home/user/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/bundler/gems/neptuno-2aaf5b34bf6f/lib/neptuno/cli/activate.rb:20:in `block in call': undefined method `keys' for "opensearch-dashboards":String (NoMethodError)
running_services = ::Neptuno::CLI::List.new.running_services.first.keys
                                                                            ^^^^^
```
